### PR TITLE
Fix for 'Unmarshalling Error: Not a number: 490.00000000000006'

### DIFF
--- a/src/1c4a/Service.ts
+++ b/src/1c4a/Service.ts
@@ -446,6 +446,7 @@ export class OneClickForAppService extends SoapService implements OneClickForApp
       .map(position => {
         if (position) {
           total += amountToCents(position.price);
+          total = Math.floor(total);
         }
 
         return position;


### PR DESCRIPTION
If you order a stamp with product id = 1032 or 49 where the price is 4.90 EUR the following error is raised when calling

await internetmarke.checkoutShoppingCart();

This error happens if the price is 4.9 EUR during calculation of the total sum for all the positions of an order due to a rounding issue with the floating point number.

### Requirements

Stamp price must be 4.9 EUR

### Description of the Change

Fixed by cutting the digits when having already converted to cent using Math.floor(total)


### Alternate Designs

none

### Why Should This Be In Core?

it fixes an error

### Benefits

You can print a stamp that costs 4.9 EUR without an error.

### Possible Drawbacks

none

### Verification Process

The order with a product id=49 or 1032 succeeds.

### Applicable Issues

none
